### PR TITLE
Use `php_packages` as a variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,4 +10,4 @@
 - name: Install php Packages
   sudo: yes
   apt: pkg={{ item }} state=latest
-  with_items: php_packages
+  with_items: "{{ php_packages }}"


### PR DESCRIPTION
Initially, it was being treated as a literal package name.

Probably due to deprecation of bare variables.